### PR TITLE
APM-299788 APM-293899 one-liner & Travis - no cd dir in one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ REQUIRE_VALID_CERTIFICATE=false
 Download the script and deploy the infrastructure:
 
 ```
-wget https://github.com/dynatrace-oss/dynatrace-aws-log-forwarder/releases/latest/download/dynatrace-aws-log-forwarder.zip && unzip -q dynatrace-aws-log-forwarder.zip && cd dynatrace-aws-log-forwarder && ./dynatrace-aws-logs.sh deploy --target-url $TARGET_URL --target-api-token $TARGET_API_TOKEN --require-valid-certificate $REQUIRE_VALID_CERTIFICATE
+wget -O dynatrace-aws-log-forwarder.zip https://github.com/dynatrace-oss/dynatrace-aws-log-forwarder/releases/latest/download/dynatrace-aws-log-forwarder.zip && unzip -qo dynatrace-aws-log-forwarder.zip && ./dynatrace-aws-logs.sh deploy --target-url $TARGET_URL --target-api-token $TARGET_API_TOKEN --require-valid-certificate $REQUIRE_VALID_CERTIFICATE
 ```
 
 #### Usage and options reference - deploy

--- a/build-release-package.sh
+++ b/build-release-package.sh
@@ -48,6 +48,8 @@ rm -rf $LAMBDA_BUILD_DIR
 mkdir $PACKAGE_BUILD_DIR
 
 cp README.md dynatrace-aws-logs.sh $LAMBDA_ZIP_NAME dynatrace-aws-log-forwarder-template.yaml $PACKAGE_BUILD_DIR
-zip $PACKAGE_ZIP_NAME $PACKAGE_BUILD_DIR/*
+cd $PACKAGE_BUILD_DIR
+zip ../$PACKAGE_ZIP_NAME *
+cd ..
 
 rm -rf $PACKAGE_BUILD_DIR


### PR DESCRIPTION
The version before ended me up with multiple levels of directories + it kept changing the directory I'm in every time I called the one-liner. 

I called it again and again to try to download new (test) release, but (and this is customer use case to me) also whenever I had some mistake in the setting of env_vars. Ofc, it would be best to run just the deploy, and spare yourself/github the wget, but this requires you to dive into the content of the one-liner, rather than a no-brainer of running the same command again.

![image](https://user-images.githubusercontent.com/50921490/119456562-13edbe00-bd3b-11eb-805f-c8366ba4225d.png)