### PR TITLE
NOISSUE fix no info on Lambda being updated when stack changeset is empty

### DIFF
--- a/dynatrace-aws-logs.sh
+++ b/dynatrace-aws-logs.sh
@@ -202,7 +202,7 @@ arguments:
   LAMBDA_ARN=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" \
      --query "Stacks[0].Outputs[?OutputKey=='LambdaArn'][OutputValue]" --output text)
 
-  echo; echo "Deployed Lambda changes to $LAMBDA_ARN"
+  echo; echo "Updated Lambda code of $LAMBDA_ARN"
   aws lambda update-function-code --function-name "$LAMBDA_ARN" --zip-file fileb://"$LAMBDA_ZIP_NAME" > /dev/null
 
   # SHOW OUTPUTS

--- a/dynatrace-aws-logs.sh
+++ b/dynatrace-aws-logs.sh
@@ -199,15 +199,14 @@ arguments:
     UseExistingActiveGate="$USE_EXISTING_ACTIVE_GATE" TenantId="$TENANT_ID" DynatracePaasToken="$TARGET_PAAS_TOKEN" \
     --no-fail-on-empty-changeset
 
-  # SHOW OUTPUTS
-  aws cloudformation describe-stacks --stack-name "$STACK_NAME" --query "Stacks[0].Outputs"
-
   LAMBDA_ARN=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" \
      --query "Stacks[0].Outputs[?OutputKey=='LambdaArn'][OutputValue]" --output text)
 
-  echo; echo "Deploying Lambda changes to $LAMBDA_ARN"
+  echo; echo "Deployed Lambda changes to $LAMBDA_ARN"
   aws lambda update-function-code --function-name "$LAMBDA_ARN" --zip-file fileb://"$LAMBDA_ZIP_NAME" > /dev/null
 
+  # SHOW OUTPUTS
+  aws cloudformation describe-stacks --stack-name "$STACK_NAME" --query "Stacks[0].Outputs"
   ;;
 
 "subscribe")

--- a/dynatrace-aws-logs.sh
+++ b/dynatrace-aws-logs.sh
@@ -202,8 +202,8 @@ arguments:
   LAMBDA_ARN=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" \
      --query "Stacks[0].Outputs[?OutputKey=='LambdaArn'][OutputValue]" --output text)
 
-  echo; echo "Updated Lambda code of $LAMBDA_ARN"; echo
   aws lambda update-function-code --function-name "$LAMBDA_ARN" --zip-file fileb://"$LAMBDA_ZIP_NAME" > /dev/null
+  echo; echo "Updated Lambda code of $LAMBDA_ARN"; echo
 
   # SHOW OUTPUTS
   aws cloudformation describe-stacks --stack-name "$STACK_NAME" --query "Stacks[0].Outputs"

--- a/dynatrace-aws-logs.sh
+++ b/dynatrace-aws-logs.sh
@@ -199,13 +199,15 @@ arguments:
     UseExistingActiveGate="$USE_EXISTING_ACTIVE_GATE" TenantId="$TENANT_ID" DynatracePaasToken="$TARGET_PAAS_TOKEN" \
     --no-fail-on-empty-changeset
 
+  # SHOW OUTPUTS
+  aws cloudformation describe-stacks --stack-name "$STACK_NAME" --query "Stacks[0].Outputs"
+
   LAMBDA_ARN=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" \
      --query "Stacks[0].Outputs[?OutputKey=='LambdaArn'][OutputValue]" --output text)
 
-  aws lambda update-function-code --function-name "$LAMBDA_ARN" --zip-file fileb://"$LAMBDA_ZIP_NAME" > /dev/null
+  echo; echo "Deploying Lambda changes to $LAMBDA_ARN"
+  aws lambda update-function-code --function-name "$LAMBDA_ARN" --zip-file fileb://"$LAMBDA_ZIP_NAME"
 
-  # SHOW OUTPUTS
-  aws cloudformation describe-stacks --stack-name "$STACK_NAME" --query "Stacks[0].Outputs"
   ;;
 
 "subscribe")

--- a/dynatrace-aws-logs.sh
+++ b/dynatrace-aws-logs.sh
@@ -202,7 +202,7 @@ arguments:
   LAMBDA_ARN=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" \
      --query "Stacks[0].Outputs[?OutputKey=='LambdaArn'][OutputValue]" --output text)
 
-  echo; echo "Updated Lambda code of $LAMBDA_ARN"
+  echo; echo "Updated Lambda code of $LAMBDA_ARN"; echo
   aws lambda update-function-code --function-name "$LAMBDA_ARN" --zip-file fileb://"$LAMBDA_ZIP_NAME" > /dev/null
 
   # SHOW OUTPUTS

--- a/dynatrace-aws-logs.sh
+++ b/dynatrace-aws-logs.sh
@@ -206,7 +206,7 @@ arguments:
      --query "Stacks[0].Outputs[?OutputKey=='LambdaArn'][OutputValue]" --output text)
 
   echo; echo "Deploying Lambda changes to $LAMBDA_ARN"
-  aws lambda update-function-code --function-name "$LAMBDA_ARN" --zip-file fileb://"$LAMBDA_ZIP_NAME"
+  aws lambda update-function-code --function-name "$LAMBDA_ARN" --zip-file fileb://"$LAMBDA_ZIP_NAME" > /dev/null
 
   ;;
 


### PR DESCRIPTION
Example output:

![image](https://user-images.githubusercontent.com/50921490/125285160-a6ade080-e31a-11eb-8e86-cd22309b0e7f.png)

[cloudshell-user@ip-10-1-157-79 ~]$ ./dynatrace-aws-logs.sh deploy --use-existing-active-gate true

Deployment script will use following parameters:
TARGET_URL="https://ec2-18-232-177-51.compute-1.amazonaws.com:9999/e/jxw01498", TARGET_API_TOKEN=*****, USE_EXISTING_ACTIVE_GATE="true", TARGET_PAAS_TOKEN=*****, REQUIRE_VALID_CERTIFICATE="false", STACK_NAME="BeluPerfLogsCLientSecond"
Deploying stack BeluPerfLogsCLientSecond

Waiting for changeset to be created..

No changes to deploy. Stack BeluPerfLogsCLientSecond is up to date
[
    {
        "OutputKey": "FirehoseArn",
        "OutputValue": "arn:aws:firehose:us-east-1:908047316593:deliverystream/BeluPerfLogsCLientSecond-FirehoseLogStreams-yFbrfo6WxsC8",
        "Description": "Firehose ARN"
    },
    {
        "OutputKey": "LambdaArn",
        "OutputValue": "arn:aws:lambda:us-east-1:908047316593:function:BeluPerfLogsCLientSecond-Lambda-oxy1d5DDH2FV",
        "Description": "Lambda ARN"
    },
    {
        "OutputKey": "CloudWatchLogsRoleArn",
        "OutputValue": "arn:aws:iam::908047316593:role/BeluPerfLogsCLientSecond-CloudWatchLogsRole-SDQBYLQCVDEN",
        "Description": "CloudWatch Logs role ARN allowing streaming to Firehose"
    }
]

Deploying Lambda changes to arn:aws:lambda:us-east-1:908047316593:function:BeluPerfLogsCLientSecond-Lambda-oxy1d5DDH2FV
{
    "FunctionName": "BeluPerfLogsCLientSecond-Lambda-oxy1d5DDH2FV",
    "FunctionArn": "arn:aws:lambda:us-east-1:908047316593:function:BeluPerfLogsCLientSecond-Lambda-oxy1d5DDH2FV",
    "Runtime": "python3.8",
    "Role": "arn:aws:iam::908047316593:role/BeluPerfLogsCLientSecond-LambdaRole-XJJ44269MPD5",
    "Handler": "index.handler",
    "CodeSize": 934056,
    "Description": "",
    "Timeout": 60,
    "MemorySize": 256,
    "LastModified": "2021-07-08T10:48:58.465+0000",
    "CodeSha256": "wBLjyTtAz2IhhF6TTE6c9fkJAHuSxh5/qjHG/209BW4=",
    "Version": "$LATEST",
    "Environment": {
        "Variables": {
            "DYNATRACE_API_KEY": "dt0c01.4POPEI4M5Z3TBJDITHRTJBKR.TRFUPY3OR3BPN5EXU45HMW7MRYUJMOLXQ7US3XZLEG6OI3OBKIRV4M22777GDI2I",
            "DYNATRACE_ENV_URL": "https://ec2-18-232-177-51.compute-1.amazonaws.com:9999/e/jxw01498",
            "DEBUG": "false",
            "VERIFY_SSL": "false"
        }
    },
    "TracingConfig": {
        "Mode": "PassThrough"
    },
    "RevisionId": "1b9d95eb-2ac5-4706-a014-ab4195d5f595",
    "State": "Active",
    "LastUpdateStatus": "Successful",
    "PackageType": "Zip"
}
[cloudshell-user@ip-10-1-157-79 ~]$ 