### PR TITLE
NOISSUE: Remove expensive metrics. To be restored with APM-306046

### DIFF
--- a/src/logs/self_monitoring/sfm.py
+++ b/src/logs/self_monitoring/sfm.py
@@ -109,17 +109,19 @@ class SelfMonitoringContext:
         metrics.append(_prepare_cloudwatch_metric(
             "Kinesis record.data decompressed size", self._record_data_decompressed_size, "Bytes", common_dimensions))
 
-        for log_group, log_entries_count in self._log_entries_by_log_group.items():
-            metrics.append(_prepare_cloudwatch_metric(
-                "Log entries by LogGroup", log_entries_count, "None",
-                common_dimensions + [{"Name": "log_group", "Value": log_group}]
-            ))
-
-        for log_group, log_content_len in self._log_content_len_by_log_group.items():
-            metrics.append(_prepare_cloudwatch_metric(
-                "Log content length by LogGroup", log_content_len, "None",
-                common_dimensions + [{"Name": "log_group", "Value": log_group}]
-            ))
+        # TO BE RESTORED IN DIFFERENT WAY IN APM-306046
+        # please remove this then
+        # for log_group, log_entries_count in self._log_entries_by_log_group.items():
+        #     metrics.append(_prepare_cloudwatch_metric(
+        #         "Log entries by LogGroup", log_entries_count, "None",
+        #         common_dimensions + [{"Name": "log_group", "Value": log_group}]
+        #     ))
+        #
+        # for log_group, log_content_len in self._log_content_len_by_log_group.items():
+        #     metrics.append(_prepare_cloudwatch_metric(
+        #         "Log content length by LogGroup", log_content_len, "None",
+        #         common_dimensions + [{"Name": "log_group", "Value": log_group}]
+        #     ))
 
         metrics.append(_prepare_cloudwatch_metric(
             "Batches prepared", self._batches_prepared, "None", common_dimensions))

--- a/tests/unit/logs/self_monitoring/test_sfm.py
+++ b/tests/unit/logs/self_monitoring/test_sfm.py
@@ -64,34 +64,34 @@ def test_self_monitoring_context():
             'Unit': 'Bytes',
             'Values': [2000]
         },
-        {
-            'Dimensions': [{'Name': 'function_name', 'Value': 'my-lambda-function'},
-                           {'Name': 'log_group', 'Value': 'logGroup1'}],
-            'MetricName': 'Log entries by LogGroup',
-            'Unit': 'None',
-            'Value': 200
-        },
-        {
-            'Dimensions': [{'Name': 'function_name', 'Value': 'my-lambda-function'},
-                           {'Name': 'log_group', 'Value': 'logGroup2'}],
-            'MetricName': 'Log entries by LogGroup',
-            'Unit': 'None',
-            'Value': 50
-        },
-        {
-            'Dimensions': [{'Name': 'function_name', 'Value': 'my-lambda-function'},
-                           {'Name': 'log_group', 'Value': 'logGroup1'}],
-            'MetricName': 'Log content length by LogGroup',
-            'Unit': 'None',
-            'Value': 2000
-        },
-        {
-            'Dimensions': [{'Name': 'function_name', 'Value': 'my-lambda-function'},
-                           {'Name': 'log_group', 'Value': 'logGroup2'}],
-            'MetricName': 'Log content length by LogGroup',
-            'Unit': 'None',
-            'Value': 2000
-        },
+        # {
+        #     'Dimensions': [{'Name': 'function_name', 'Value': 'my-lambda-function'},
+        #                    {'Name': 'log_group', 'Value': 'logGroup1'}],
+        #     'MetricName': 'Log entries by LogGroup',
+        #     'Unit': 'None',
+        #     'Value': 200
+        # },
+        # {
+        #     'Dimensions': [{'Name': 'function_name', 'Value': 'my-lambda-function'},
+        #                    {'Name': 'log_group', 'Value': 'logGroup2'}],
+        #     'MetricName': 'Log entries by LogGroup',
+        #     'Unit': 'None',
+        #     'Value': 50
+        # },
+        # {
+        #     'Dimensions': [{'Name': 'function_name', 'Value': 'my-lambda-function'},
+        #                    {'Name': 'log_group', 'Value': 'logGroup1'}],
+        #     'MetricName': 'Log content length by LogGroup',
+        #     'Unit': 'None',
+        #     'Value': 2000
+        # },
+        # {
+        #     'Dimensions': [{'Name': 'function_name', 'Value': 'my-lambda-function'},
+        #                    {'Name': 'log_group', 'Value': 'logGroup2'}],
+        #     'MetricName': 'Log content length by LogGroup',
+        #     'Unit': 'None',
+        #     'Value': 2000
+        # },
         {
             'Dimensions': [{'Name': 'function_name', 'Value': 'my-lambda-function'}],
             'MetricName': 'Batches prepared',


### PR DESCRIPTION
As APM-306046 is delayed, we agreed with @mfranczak to remove most expensive SFM metrics for now. To be restored with this ticket in different approach.
This is temporary solution to protect customers from unnecessary bills 