### PR TITLE
APM-313830: Disable SFM metrics push. It does not work with newAG opt…

### DIFF
--- a/src/index.py
+++ b/src/index.py
@@ -55,10 +55,10 @@ def handler(event, lambda_context):
         log_error_with_stacktrace(e, "Exception caught in top-level handler")
         result = TransformationResult.ProcessingFailed
 
-    try:
-        context.sfm.push_sfm_to_cloudwatch()
-    except Exception as e:
-        log_error_with_stacktrace(e, "SelfMonitoring push to Cloudwatch failed")
+    # try:
+    #     context.sfm.push_sfm_to_cloudwatch()
+    # except Exception as e:
+    #     log_error_with_stacktrace(e, "SelfMonitoring push to Cloudwatch failed")
 
     return kinesis_data_transformation_response(records, result)
 


### PR DESCRIPTION
…ion at all! Lambda in VPC cannot connect to Cloudwatch at the moment.


SFM push will work as usual in existing AG setup.

It does not work in newAG setup. SFM putMetricData times out after 5 minutes (in a setup where we tweaked lambda timeout to 10 minutes; normal lambda timeout in our stack is 1 minute so lambda will time out before putMetricData times out)
Our VPC design is following: EC2 has public IP (can connect everything) and is protected by security group, only allows traffic from Lambda. 
Lambda is connect to VPC but gets no IP.
Since the subnet is public subnet and does not have NAT gateway, lambda can not obtain any IP when it reaches out to internet. So the request to public Cloudwatch endpoint is going out but response never arrives back.

So actually logs should be streaming fine (happens before putMetricData is called) but lambda will take lots of time (5 minutes putMetricData SDK timeout).

For now, I disabled SFM putMetricData at all. 
In coming days we will discuss if and how we want to redesign VPC setup to allow lambda putMetricData push. 
The solution would be to put lambda in additional private subnet that will go to internet through NAT gateway in public subnet (this way an entity without IP can send request and receive response - using NAT gw as intermediary).

Please approve, merge & release ASAP
