### PR TITLE
add descriptive name to AG EC2 in template

### DIFF
--- a/dynatrace-aws-log-forwarder-template.yaml
+++ b/dynatrace-aws-log-forwarder-template.yaml
@@ -578,6 +578,9 @@ Resources:
             DeleteOnTermination: "true"
             VolumeSize: "8"
       SecurityGroupIds: [ !Ref VPCSecurityGroup ]
+      Tags:
+        - Key: Name
+          Value: !Join [ "-", [ !Ref 'AWS::StackName', "active-gate" ] ]
       UserData:
         Fn::Base64:
           !Sub


### PR DESCRIPTION
Small change in the CloudFormation template making it so the name of EC2 containing ActiveGate is named *stack name*-active-gate.