### PR TITLE
APM-315546 block public access to S3 delivery bucket

### DIFF
--- a/dynatrace-aws-log-forwarder-template.yaml
+++ b/dynatrace-aws-log-forwarder-template.yaml
@@ -146,6 +146,11 @@ Resources:
         Rules:
           - ExpirationInDays: '7'
             Status: 'Enabled'
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
 
   DeliveryStreamRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
Tested that the bucket is created with correct permissions (public access blocked). Processed (successful or failed) logs are stored in the bucket. It's not possible to reach it from the Internet.
![logs-bucket-permissions](https://user-images.githubusercontent.com/3855168/126999633-0b7cf4ff-0e9e-4fec-82a1-80791d2b6e4c.PNG)
![logs-bucket-objects](https://user-images.githubusercontent.com/3855168/126999651-2a8be93a-f0fe-436f-9d20-8e478712973e.PNG)
