### PR TITLE
Noissue: Aurora perf test

### DIFF
--- a/tests/unit/logs/test_transformation_full.py
+++ b/tests/unit/logs/test_transformation_full.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 
 import json
+import time
 
 import pytest
 
@@ -827,6 +828,11 @@ CLOUDTRAIL_USER_IDENTITY = {
             'aws.account.id': "444000444",
             'severity': 'INFO',
             'log.source': 'rds - general logs',
+        },
+        "perf_check": {
+            "repeat_record": 10000,
+            "time_limit_sec": 5
+            # roughly 1,5MB of content, ~7MB counting whole log entry with metadata
         }
     }, id="testcase_rds_aurora_mysql_general_log"),
 
@@ -1002,8 +1008,24 @@ def test_full_transformation(testcase: dict):
     record_data_decoded = testcase["record_data_decoded"]
     expect_first_log_contains = testcase["expect_first_log_contains"]
 
-    logs_sent = logs.transformation.extract_dt_logs_from_single_record(
-        json.dumps(record_data_decoded), BATCH_METADATA, context)
+    logs_sent = []
+
+    if "perf_check" in testcase:
+        perf_check = testcase["perf_check"]
+        repeat_record = perf_check["repeat_record"]
+        time_limit_sec = perf_check["time_limit_sec"]
+
+        start_sec = time.time()
+        for i in range(repeat_record):
+            logs_sent = logs.transformation.extract_dt_logs_from_single_record(
+                json.dumps(record_data_decoded), BATCH_METADATA, context)
+        end_sec = time.time()
+        duration_sec = end_sec - start_sec
+        print(f"PERF_CHECK {duration_sec}")
+        assert duration_sec < time_limit_sec, f"Perf check: duration ({duration_sec}) should be less than limit {time_limit_sec}"
+    else:
+        logs_sent = logs.transformation.extract_dt_logs_from_single_record(
+            json.dumps(record_data_decoded), BATCH_METADATA, context)
 
     assert len(logs_sent) == len(record_data_decoded["logEvents"])
 

--- a/tests/unit/logs/test_transformation_full.py
+++ b/tests/unit/logs/test_transformation_full.py
@@ -1014,18 +1014,20 @@ def test_full_transformation(testcase: dict):
         perf_check = testcase["perf_check"]
         repeat_record = perf_check["repeat_record"]
         time_limit_sec = perf_check["time_limit_sec"]
+    else:
+        repeat_record = 1
+        time_limit_sec = None
 
-        start_sec = time.time()
-        for i in range(repeat_record):
-            logs_sent = logs.transformation.extract_dt_logs_from_single_record(
-                json.dumps(record_data_decoded), BATCH_METADATA, context)
-        end_sec = time.time()
+    start_sec = time.time()
+    for i in range(repeat_record):
+        logs_sent = logs.transformation.extract_dt_logs_from_single_record(
+            json.dumps(record_data_decoded), BATCH_METADATA, context)
+    end_sec = time.time()
+
+    if "perf_check" in testcase:
         duration_sec = end_sec - start_sec
         print(f"PERF_CHECK {duration_sec}")
         assert duration_sec < time_limit_sec, f"Perf check: duration ({duration_sec}s) should be less than limit {time_limit_sec}s"
-    else:
-        logs_sent = logs.transformation.extract_dt_logs_from_single_record(
-            json.dumps(record_data_decoded), BATCH_METADATA, context)
 
     assert len(logs_sent) == len(record_data_decoded["logEvents"])
 

--- a/tests/unit/logs/test_transformation_full.py
+++ b/tests/unit/logs/test_transformation_full.py
@@ -831,7 +831,7 @@ CLOUDTRAIL_USER_IDENTITY = {
         },
         "perf_check": {
             "repeat_record": 10000,
-            "time_limit_sec": 1
+            "time_limit_sec": 5
             # roughly 1,5MB of content, ~7MB counting whole log entry with metadata
         }
     }, id="testcase_rds_aurora_mysql_general_log"),

--- a/tests/unit/logs/test_transformation_full.py
+++ b/tests/unit/logs/test_transformation_full.py
@@ -1024,7 +1024,7 @@ def test_full_transformation(testcase: dict):
             json.dumps(record_data_decoded), BATCH_METADATA, context)
     end_sec = time.time()
 
-    if "perf_check" in testcase:
+    if time_limit_sec:
         duration_sec = end_sec - start_sec
         print(f"PERF_CHECK {duration_sec}")
         assert duration_sec < time_limit_sec, f"Perf check: duration ({duration_sec}s) should be less than limit {time_limit_sec}s"

--- a/tests/unit/logs/test_transformation_full.py
+++ b/tests/unit/logs/test_transformation_full.py
@@ -831,7 +831,7 @@ CLOUDTRAIL_USER_IDENTITY = {
         },
         "perf_check": {
             "repeat_record": 10000,
-            "time_limit_sec": 5
+            "time_limit_sec": 1
             # roughly 1,5MB of content, ~7MB counting whole log entry with metadata
         }
     }, id="testcase_rds_aurora_mysql_general_log"),
@@ -1022,7 +1022,7 @@ def test_full_transformation(testcase: dict):
         end_sec = time.time()
         duration_sec = end_sec - start_sec
         print(f"PERF_CHECK {duration_sec}")
-        assert duration_sec < time_limit_sec, f"Perf check: duration ({duration_sec}) should be less than limit {time_limit_sec}"
+        assert duration_sec < time_limit_sec, f"Perf check: duration ({duration_sec}s) should be less than limit {time_limit_sec}s"
     else:
         logs_sent = logs.transformation.extract_dt_logs_from_single_record(
             json.dumps(record_data_decoded), BATCH_METADATA, context)


### PR DESCRIPTION
I wrote quick perf test for you.
Perf test result is very good 👍 see the comment

But this is on my very fast computer. Also there might be some optimizations going on underneath. So this is not very certain but it's best what we have at the moment.

I would love to run this with randomized log content and in lambda environment with their basic vCPU.

Can you please organise this and include into codebase? I think this should be in some separate test. Otherwise this test will get very long once we add more check. Not sure how it should look like. But if transformation_full.py takes too long this might discourage devs from this test :D 



