### PR TITLE
APM 318892

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ jobs:
         # subscribe to AWS CloudWatch Logs log groups
         - ./dynatrace-aws-logs.sh subscribe --log-groups $AWS_CLOUDWATCH_LOGS_LOG_GROUP --stack-name $AWS_CLOUDFORMATION_STACK
         # execute end-to-end test
-        - ./main.py --api-token $DYNATRACE_E2E_TEST_API_KEY --log-group-name $AWS_CLOUDWATCH_LOGS_LOG_GROUP --log-stream-name $AWS_CLOUDWATCH_LOGS_LOG_STREAM --unique-message-content "${TRAVIS_COMMIT}-${TRAVIS_BUILD_NUMBER}"
+        - ./main.py --api-token $DYNATRACE_E2E_TEST_API_KEY --log-group-name $AWS_CLOUDWATCH_LOGS_LOG_GROUP --log-stream-name $AWS_CLOUDWATCH_LOGS_LOG_STREAM --unique-message-content "$(cut -c 1-8 <<< ${TRAVIS_COMMIT})-${TRAVIS_BUILD_NUMBER}"
       after_script:
         # unsubscribe from AWS CloudWatch Logs log groups
         - ./dynatrace-aws-logs.sh unsubscribe --log-groups $AWS_CLOUDWATCH_LOGS_LOG_GROUP --stack-name $AWS_CLOUDFORMATION_STACK

--- a/tests/e2e/main.py
+++ b/tests/e2e/main.py
@@ -66,7 +66,7 @@ def search_dynatrace_log_records(url_prefix,
     (using Dynatrace API) return a list of log records matching the specified query
     """
     url    = url_prefix + '/logs/search'
-    query  = 'content=' + message_content
+    query  = 'content="' + message_content + '"'
     params = {
         'from': 'now-10m',
         'limit': '1000',

--- a/tests/e2e/main.py
+++ b/tests/e2e/main.py
@@ -113,7 +113,8 @@ if __name__ == '__main__':
                         '-m',
                         action='store',
                         type=str,
-                        default='Dynatrace-AWS-Log-Forwarder-End-to-End-test-message',
+                        default='',
+                        required=True,
                         help='specify a unique log event message content')
     args = parser.parse_args()
 
@@ -121,7 +122,7 @@ if __name__ == '__main__':
     request_headers       = {'Authorization': 'Api-Token ' + args.api_token,
                             'Content-Type': 'application/json',
                             'charset': 'utf-8'}
-    message_content       = 'Dynatrace-AWS-Log-Forwarder-End-to-End-test-' + args.unique_message_content
+    message_content       = args.unique_message_content
 
     # Generate a test log event
     generate_log_event(args.log_group_name,

--- a/tests/e2e/main.py
+++ b/tests/e2e/main.py
@@ -64,9 +64,16 @@ def search_dynatrace_log_records(url_prefix,
     """
     (using Dynatrace API) return a list of log records matching the specified query
     """
-    url = url_prefix + '/logs/search?' + 'from=now-5m&limit=1000&query=aws.service%3D%22lambda%22%20AND%20content%3D%22' + message_content + '%22%20AND%20timestamp%3D%22' + str(epoch_timestamp_in_ms) + '%22&sort=-timestamp'
+    url = url_prefix + '/logs/search'
+    params = {
+        'from': 'now-10m',
+        'limit': '1000',
+        'query': 'content=' + message_content,
+        'sort': '-timestamp'
+    }
     response = requests.get(url,
-                            headers=request_headers)
+                            headers=request_headers,
+                            params=params)
 
     # check, if response status code is OK
     if response.status_code != requests.codes.ok:

--- a/tests/e2e/main.py
+++ b/tests/e2e/main.py
@@ -133,8 +133,8 @@ if __name__ == '__main__':
     time_elapsed = 0
     while bool(dynatrace_log_records_search_results) is False:
         print('Waiting for log events to be picked up by the cluster...')
-        time.sleep(10)
-        time_elapsed = time_elapsed + 10
+        time.sleep(20)
+        time_elapsed = time_elapsed + 20
         dynatrace_log_records_search_results = search_dynatrace_log_records(args.url_prefix,message_content)['results']
         # Fail the test after 5min
         if time_elapsed == 300:


### PR DESCRIPTION
Fix failing  AWS Log Forwarder builds on `master` branch due to end-to-end test errors.

Changes:
1. Change query generation method to requests params
2. Change unique message content
3. Increase sleep time by 10sec
4. Add timestamp as part of content in query