### PR TITLE
Fix build failing do to missing dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ jobs:
       language: shell
       services: docker
       install:
+        # setup PIP
+        - sudo apt-get install -y python3-pip
         # set up awscli packages
         - python3 -m pip install --user awscli==1.20.9
       before_script:
@@ -48,6 +50,8 @@ jobs:
       if: branch = master OR type = pull_request OR tag =~ /^release.*$/
       language: shell
       install:
+        # setup PIP
+        - sudo apt-get install -y python3-pip
         # set up awscli packages
         - python3 -m pip install --user awscli==1.20.9
         # set up e2e packages
@@ -83,6 +87,8 @@ jobs:
       if: tag =~ /^release.*$/
       language: shell
       install:
+        # setup PIP
+        - sudo apt-get install -y python3-pip
         # set up awscli packages
         - python3 -m pip install --user awscli==1.20.9
       script: skip


### PR DESCRIPTION
This PR will fix AWS Log Forwarder builds failing do to missing Python dependencies.

## Resources
1. [JIRA - APM-338282](https://dev-jira.dynatrace.org/browse/APM-338282)