### PR TITLE
feat: Adding log retention

### DIFF
--- a/dynatrace-aws-log-forwarder-template.yaml
+++ b/dynatrace-aws-log-forwarder-template.yaml
@@ -85,6 +85,7 @@ Resources:
 
   LambdaLogGroup:
     Type: AWS::Logs::LogGroup
+    DependsOn: Lambda
     Properties:
       LogGroupName: !Sub "/aws/lambda/${Lambda}"
       RetentionInDays: 90

--- a/dynatrace-aws-log-forwarder-template.yaml
+++ b/dynatrace-aws-log-forwarder-template.yaml
@@ -86,7 +86,7 @@ Resources:
   LambdaLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub "/aws/codebuild/${Lambda}"
+      LogGroupName: !Sub "/aws/lambda/${Lambda}"
       RetentionInDays: 90
 
   LambdaRole:

--- a/dynatrace-aws-log-forwarder-template.yaml
+++ b/dynatrace-aws-log-forwarder-template.yaml
@@ -83,6 +83,12 @@ Resources:
           SubnetIds: [ !Ref VPCPrivateSubnet  ]
         - !Ref "AWS::NoValue"
 
+  LambdaLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/codebuild/${Lambda}"
+      RetentionInDays: 90
+
   LambdaRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
The following change adds log retention to the Lambda functions LogGroup.
This should help reduce the amount of Lambda logs stored in AWS which will cut down on CloudWatch log storage costs.

In this propose I have defaulted to 90 days as a good baseline, however we might want to reduce this further.