### PR TITLE
feature: Adding export name

### DIFF
--- a/dynatrace-aws-log-forwarder-template.yaml
+++ b/dynatrace-aws-log-forwarder-template.yaml
@@ -746,10 +746,14 @@ Outputs:
   FirehoseArn:
     Description: "Firehose ARN"
     Value: !GetAtt FirehoseLogStreams.Arn
+    Export:
+      Name: !Join [ ":", [ !Ref "AWS::StackName", FirehoseARN ] ]
 
   CloudWatchLogsRoleArn:
     Description: "CloudWatch Logs role ARN allowing streaming to Firehose"
     Value: !GetAtt CloudWatchLogsRole.Arn
+    Export:
+      Name: !Join [ ":", [ !Ref "AWS::StackName", CloudWatchARN ] ]
 
   EC2ActiveGateHostname:
     Description: "EC2ActiveGateHostname"


### PR DESCRIPTION
This feature change adds export names to the `FirehoseArn` and `CloudWatchLogsRoleArn` output values.
This is done so you could dynamically import the values to a LogSubscriptions via a [Function ImportValue](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-importvalue.html).

I chose a very generic name of AWS::StackName:(FirehoseARN/CloudWatchARN) however this is up to debate.