### PR TITLE
feature: Adding log retention

### DIFF
--- a/dynatrace-aws-logs.sh
+++ b/dynatrace-aws-logs.sh
@@ -259,6 +259,12 @@ EOF
   aws lambda update-function-code --function-name "$LAMBDA_ARN" --zip-file fileb://"$LAMBDA_ZIP_NAME" > /dev/null
   echo; echo "Updated Lambda code of $LAMBDA_ARN"; echo
 
+  LAMBDA_NAME=$(aws cloudformation describe-stack-resource --stack-name "$STACK_NAME" \
+     --logical-resource-id Lambda --query "StackResourceDetail.PhysicalResourceId" --output text)
+    
+  aws logs put-retention-policy --log-group-name "/aws/lambda/$LAMBDA_NAME" --retention-in-days 90
+  echo; echo "Adding log retention policy of 90 days"; echo
+
   # SHOW OUTPUTS
   aws cloudformation describe-stacks --stack-name "$STACK_NAME" --query "Stacks[0].Outputs"
   ;;


### PR DESCRIPTION
The following feature change adds log retention to the Lambda functions LogGroup.
This should help reduce the amount of Lambda logs stored in AWS which will cut down on CloudWatch log storage costs.

In this propose I have defaulted to 90 days as a good baseline, however we might want to reduce this further.

As found per my previous PR https://github.com/dynatrace-oss/dynatrace-aws-log-forwarder/pull/50 this is set in the run script to support the updating of the stack.