### PR TITLE
APM-379036 #52 ActiveGate state check fails for running ActiveGate

### DIFF
--- a/dynatrace-aws-log-forwarder-template.yaml
+++ b/dynatrace-aws-log-forwarder-template.yaml
@@ -56,7 +56,6 @@ Resources:
   Lambda:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Join ["-", [!Ref AWS::StackName, "aws-log-fwd-function"]]
       Code:
         ZipFile: |
           def handler(event, context):
@@ -88,7 +87,6 @@ Resources:
   LambdaRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Join [".", [!Ref AWS::StackName, "aws-log-fwd.function-role"]]
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -123,8 +121,7 @@ Resources:
 
   FirehoseLogStreams:
     Type: AWS::KinesisFirehose::DeliveryStream
-    Properties: 
-      DeliveryStreamName: !Join [".", [!Ref AWS::StackName, "aws-log-fwd.delivery-stream"]]
+    Properties:
       DeliveryStreamType: DirectPut
       ExtendedS3DestinationConfiguration:
         BucketARN: !GetAtt DeliveryBucket.Arn
@@ -146,7 +143,6 @@ Resources:
   DeliveryBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Join [".", [!Ref AWS::StackName, "aws-log-fwd.s3-bucket"]]
       LifecycleConfiguration:
         Rules:
           - ExpirationInDays: '7'
@@ -160,7 +156,6 @@ Resources:
   DeliveryStreamRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Join [".", [!Ref AWS::StackName, "aws-log-fwd.delivery-stream-role"]]
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -199,7 +194,6 @@ Resources:
   CloudWatchLogsRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Join [".", [!Ref AWS::StackName, "aws-log-fwd.cloudwatch-logs-role"]]
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -593,7 +587,7 @@ Resources:
       SecurityGroupIds: [ !Ref VPCSecurityGroup ]
       Tags:
         - Key: Name
-          Value: !Join [ ".", [ !Ref 'AWS::StackName', "aws-log-fwd.active-gate" ] ]
+          Value: !Join [ "-", [ !Ref 'AWS::StackName', "active-gate" ] ]
       UserData:
         Fn::Base64:
           !Sub
@@ -640,9 +634,6 @@ Resources:
       CidrBlock: "172.31.0.0/16"
       EnableDnsSupport: true
       EnableDnsHostnames: true
-      Tags:
-        - Key: Name
-          Value: !Join [ ".", [ !Ref 'AWS::StackName', "aws-log-fwd.active-gate" ] ]
 
   VPCPublicSubnet:
     Condition: DeployAGwithVPC
@@ -652,9 +643,6 @@ Resources:
       AvailabilityZone: !Select [ 0, !GetAZs ]
       CidrBlock: 172.31.1.0/27
       MapPublicIpOnLaunch: true
-      Tags:
-        - Key: Name
-          Value: !Join [ ".", [ !Ref 'AWS::StackName', "aws-log-fwd.active-gate" ] ]
 
   VPCPrivateSubnet:
     Condition: DeployAGwithVPC
@@ -664,18 +652,11 @@ Resources:
       AvailabilityZone: !Select [ 0, !GetAZs ]
       CidrBlock: 172.31.2.0/27
       MapPublicIpOnLaunch: false
-      Tags:
-        - Key: Name
-          Value: !Join [ ".", [ !Ref 'AWS::StackName', "aws-log-fwd.active-gate" ] ]
 
   VPCInternetGateway:
     Condition: DeployAGwithVPC
     Type: AWS::EC2::InternetGateway
     DependsOn: VPC
-    Properties:
-      Tags:
-        - Key: Name
-          Value: !Join [ ".", [ !Ref 'AWS::StackName', "aws-log-fwd.active-gate" ] ]
 
   VPCInternetGatewayAttach:
     Condition: DeployAGwithVPC
@@ -689,9 +670,6 @@ Resources:
     Type: AWS::EC2::EIP
     Properties:
       Domain: VPC
-      Tags:
-        - Key: Name
-          Value: !Join [ ".", [ !Ref 'AWS::StackName', "aws-log-fwd.active-gate" ] ]
 
   VPCNatGateway:
     Condition: DeployAGwithVPC
@@ -699,18 +677,12 @@ Resources:
     Properties:
       AllocationId: !GetAtt VPCNatGatewayElasticIP.AllocationId
       SubnetId: !Ref VPCPublicSubnet
-      Tags:
-        - Key: Name
-          Value: !Join [ ".", [ !Ref 'AWS::StackName', "aws-log-fwd.active-gate" ] ]
 
   VPCPublicRouteTable:
     Condition: DeployAGwithVPC
     Type: AWS::EC2::RouteTable
     Properties:
       VpcId: !Ref VPC
-      Tags:
-        - Key: Name
-          Value: !Join [ ".", [ !Ref 'AWS::StackName', "aws-log-fwd.active-gate" ] ]
 
   VPCPublicRouteInternet:
     Condition: DeployAGwithVPC
@@ -733,9 +705,6 @@ Resources:
     Type: AWS::EC2::RouteTable
     Properties:
       VpcId: !Ref VPC
-      Tags:
-        - Key: Name
-          Value: !Join [ ".", [ !Ref 'AWS::StackName', "aws-log-fwd.active-gate" ] ]
 
   VPCPrivateRouteToNat:
     Condition: DeployAGwithVPC
@@ -758,9 +727,6 @@ Resources:
     Properties:
       GroupDescription: Allow ActiveGate ingress
       VpcId: !Ref VPC
-      Tags:
-        - Key: Name
-          Value: !Join [ ".", [ !Ref 'AWS::StackName', "aws-log-fwd.active-gate" ] ]
 
   VPCSecurityGroupActiveGateInbound:
     Condition: DeployAGwithVPC

--- a/dynatrace-aws-logs.sh
+++ b/dynatrace-aws-logs.sh
@@ -250,7 +250,7 @@ EOF
 
   echo "Deploying stack $STACK_NAME. This might take up to 10 minutes."
 
-  aws cloudformation deploy --stack "$STACK_NAME" --template-file "$TEMPLATE_FILE" --capabilities CAPABILITY_NAMED_IAM \
+  aws cloudformation deploy --stack "$STACK_NAME" --template-file "$TEMPLATE_FILE" --capabilities CAPABILITY_IAM \
     --parameter-overrides DynatraceEnvironmentUrl="$TARGET_URL" DynatraceApiKey="$TARGET_API_TOKEN" VerifySSLTargetActiveGate="$REQUIRE_VALID_CERTIFICATE" \
     UseExistingActiveGate="$USE_EXISTING_ACTIVE_GATE" TenantId="$TENANT_ID" DynatracePaasToken="$TARGET_PAAS_TOKEN" \
     --no-fail-on-empty-changeset


### PR DESCRIPTION
we need a release of aws-log-forwarder for hiding of createAG option

I think Aws cloud-formation is better than Azure arm json template in that respect, but have no time to fully check - we can check it later on, but for now for the release I'm reverting all changes from Kamil's PR:
https://github.com/dynatrace-oss/dynatrace-aws-log-forwarder/pull/65/files
[APM-352264](https://dev-jira.dynatrace.org/browse/APM-352264) Check if storage account name in Azure Log forwarder is being randomized