### PR TITLE
NOISSUE Fix link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Please follow these steps:
 Thank you! 
 
 ## Overview
-See the [official project documentation](https://www.dynatrace.com/support/help/technology-support/cloud-platforms/amazon-web-services/aws-log-forwarder/) for overview and user's manual. This readme contains only additional technical details.
+See the [official project documentation](https://www.dynatrace.com/support/help/shortlink/aws-log-fwd) for overview and user's manual. This readme contains only additional technical details.
 
 ### Architecture
 


### PR DESCRIPTION
The URL to docs changed due to changes in the structure. Changed it to a permanent one that always works regardless of the placement of the article in the doc structure. 