### PR TITLE
Bugfix/pclouds 3435 aws log forwarder handle incorrect event schema gracefully

### DIFF
--- a/src/index.py
+++ b/src/index.py
@@ -39,8 +39,8 @@ def handler(event, lambda_context):
 
     try:
         records = event['records']
-    except KeyError:
-        raise BadSchemaError('records')
+    except KeyError as exc:
+        raise BadSchemaError('records') from exc
 
     try:
         is_logs, plaintext_records = input_records_decoder.check_records_list_if_logs_end_decode(records, context)

--- a/src/index.py
+++ b/src/index.py
@@ -16,10 +16,12 @@ import os
 from enum import Enum
 
 from logs import input_records_decoder, main
+from logs.input_records_decoder import BadSchemaError
 from logs.logs_sender import CallThrottlingException, DYNATRACE_LOG_INGEST_CONTENT_DEFAULT_MAX_LENGTH
 from logs.models.batch_metadata import BatchMetadata
 from util.context import Context
 from util.logging import log_error_with_stacktrace, log_multiline_message
+
 
 
 def handler(event, lambda_context):
@@ -35,7 +37,10 @@ def handler(event, lambda_context):
 
     context = get_context(lambda_context)
 
-    records = event['records']
+    try:
+        records = event['records']
+    except KeyError:
+        raise BadSchemaError('records')
 
     try:
         is_logs, plaintext_records = input_records_decoder.check_records_list_if_logs_end_decode(records, context)

--- a/src/logs/input_records_decoder.py
+++ b/src/logs/input_records_decoder.py
@@ -83,3 +83,12 @@ def sfm_report_kinesis_records_age(records, context):
     except Exception as e:
         log_error_with_stacktrace(e, "Failed to calculate Kinesis Record Delay Self Monitoring",
                                   "sfm-record-delay-calc-exception")
+
+class BadSchemaError(Exception):
+    '''BadSchemaError is raised when the received logs do not meet the expected format.'''
+
+    def __init__(self, erroneous_field: str) -> None:
+        message = f"""Lambda was called with an event of unrecognized schema.
+        Make sure you have configured everything correctly. Unexpected problem happened when trying to parse field: {erroneous_field}
+        """
+        super().__init__(message)

--- a/src/logs/input_records_decoder.py
+++ b/src/logs/input_records_decoder.py
@@ -88,7 +88,8 @@ class BadSchemaError(Exception):
     '''BadSchemaError is raised when the received logs do not meet the expected format.'''
 
     def __init__(self, erroneous_field: str) -> None:
-        message = f"""Lambda was called with an event of unrecognized schema.
-        Make sure you have configured everything correctly. Unexpected problem happened when trying to parse field: {erroneous_field}
+        message = f"""Lambda has been called with an event of unrecognized schema.
+        Make sure you have configured your log groups correctly, as in the documentation https://docs.dynatrace.com/docs/shortlink/aws-log-fwd.
+        An unexpected problem happened when trying to parse: {erroneous_field}.
         """
         super().__init__(message)


### PR DESCRIPTION
Small PR to explicitly raise an exception, when the received event cannot be parsed.

After the changes, the example log in CloudWatch looks like this:

![image](https://github.com/dynatrace-oss/dynatrace-aws-log-forwarder/assets/141156573/af44a257-1bd5-476a-b7ea-879f29f06c9e)
