### PR TITLE
Pclouds 3370 lambda integration add a link to generic lambda in log forwarder logs

### DIFF
--- a/src/config/lambda.json
+++ b/src/config/lambda.json
@@ -35,7 +35,7 @@
           "pattern": "if( starts_with(log_content, '[ERROR]'), &'ERROR', &'INFO', @)"
         },
         {
-          "key": "dt.source_entity",
+          "key": "dt.entity.aws_lambda_function",
           "pattern": "dt_meid_lambda_function(function_name, region, account_id)"
         }
       ]

--- a/src/config/lambda.json
+++ b/src/config/lambda.json
@@ -27,6 +27,10 @@
           "pattern": "format_arn('arn:{}:lambda:{}:{}:function:{}', [partition, region, account_id, function_name])"
         },
         {
+          "key": "faas.id",
+          "pattern": "format_arn('arn:{}:lambda:{}:{}:function:{}', [partition, region, account_id, function_name])"
+        },
+        {
           "key": "severity",
           "pattern": "if( starts_with(log_content, '[ERROR]'), &'ERROR', &'INFO', @)"
         },

--- a/tests/unit/logs/metadata_engine/entity_id/test_me_id.py
+++ b/tests/unit/logs/metadata_engine/entity_id/test_me_id.py
@@ -80,3 +80,39 @@ def test_meid_in_credentials_v2_core_services__murmurhash_awsseed():
     meid = jmes_custom_functions._func_dt_meid_rds_v2(dbInstanceArn)
     assert meid == real_meid_from_dt_cluster, "From jmesPath customFunctions - seed should be -512093083:"
     assert id == real_long_id_from_dt_cluster
+
+
+def test_meid_credentials_v1_v2_builtin_service_lambda_md5():
+    #arn = "arn:aws:lambda:us-east-1:444652832050:function:metricstreamprocessorinte-CloudWatchStreamFunction-bpIv5lY7e0k8"
+    input = "metricstreamprocessorinte-CloudWatchStreamFunction-bpIv5lY7e0k8" + \
+            "us-east-1" + \
+            "_" + \
+            "444652832050"
+
+    id = me_id._legacy_entity_id_md5(input)
+    meid = me_id.meid_md5("AWS_LAMBDA_FUNCTION", input)
+    meid_from_format = me_id.meid_md5("AWS_LAMBDA_FUNCTION", format_required("{}{}_{}", [
+        "metricstreamprocessorinte-CloudWatchStreamFunction-bpIv5lY7e0k8", #awsArnParts[6] - name
+        "us-east-1",    # awsArnParts[3] - region
+        "444652832050"  # awsArnParts[4] - account
+    ]))
+
+    assert id == -6510566195266530280
+    assert meid == "AWS_LAMBDA_FUNCTION-A5A5D28A3478D418"
+    assert meid == meid_from_format
+
+
+def test_meid_credentials_v2_supporting_service_lambda__murmurhash():
+    input = "lambdaarn:aws:lambda:us-east-1:444652832050:function:metricstreamprocessorinte-CloudWatchStreamFunction-bpIv5lY7e0k8"
+
+    id = me_id._murmurhash2_64A(input)
+    meid = me_id.meid_murmurhash("CUSTOM_DEVICE", input)
+    meid_from_list = me_id.meid_murmurhash("CUSTOM_DEVICE", format_required("{}{}", [
+        "lambda",   ##supporting service id/shortname
+        "arn:aws:lambda:us-east-1:444652832050:function:metricstreamprocessorinte-CloudWatchStreamFunction-bpIv5lY7e0k8" #arn
+    ]))
+
+    assert id == -2879273126824973378
+    assert meid == "CUSTOM_DEVICE-D80AC458A044EBBE"
+    assert meid == meid_from_list
+

--- a/tests/unit/logs/metadata_engine/entity_id/test_me_id.py
+++ b/tests/unit/logs/metadata_engine/entity_id/test_me_id.py
@@ -83,14 +83,14 @@ def test_meid_in_credentials_v2_core_services__murmurhash_awsseed():
 
 
 def test_meid_credentials_v1_v2_builtin_service_lambda_md5():
-    #arn = "arn:aws:lambda:us-east-1:444652832050:function:metricstreamprocessorinte-CloudWatchStreamFunction-bpIv5lY7e0k8"
-    input = "metricstreamprocessorinte-CloudWatchStreamFunction-bpIv5lY7e0k8" + \
+    # arn: "arn:aws:lambda:us-east-1:444652832050:function:metricstreamprocessorinte-CloudWatchStreamFunction-bpIv5lY7e0k8"
+    id_calc_input = "metricstreamprocessorinte-CloudWatchStreamFunction-bpIv5lY7e0k8" + \
             "us-east-1" + \
             "_" + \
             "444652832050"
 
-    id = me_id._legacy_entity_id_md5(input)
-    meid = me_id.meid_md5("AWS_LAMBDA_FUNCTION", input)
+    id = me_id._legacy_entity_id_md5(id_calc_input)
+    meid = me_id.meid_md5("AWS_LAMBDA_FUNCTION", id_calc_input)
     meid_from_format = me_id.meid_md5("AWS_LAMBDA_FUNCTION", format_required("{}{}_{}", [
         "metricstreamprocessorinte-CloudWatchStreamFunction-bpIv5lY7e0k8", #awsArnParts[6] - name
         "us-east-1",    # awsArnParts[3] - region
@@ -103,10 +103,10 @@ def test_meid_credentials_v1_v2_builtin_service_lambda_md5():
 
 
 def test_meid_credentials_v2_supporting_service_lambda__murmurhash():
-    input = "lambdaarn:aws:lambda:us-east-1:444652832050:function:metricstreamprocessorinte-CloudWatchStreamFunction-bpIv5lY7e0k8"
+    id_calc_input = "lambdaarn:aws:lambda:us-east-1:444652832050:function:metricstreamprocessorinte-CloudWatchStreamFunction-bpIv5lY7e0k8"
 
-    id = me_id._murmurhash2_64A(input)
-    meid = me_id.meid_murmurhash("CUSTOM_DEVICE", input)
+    id = me_id._murmurhash2_64A(id_calc_input)
+    meid = me_id.meid_murmurhash("CUSTOM_DEVICE", id_calc_input)
     meid_from_list = me_id.meid_murmurhash("CUSTOM_DEVICE", format_required("{}{}", [
         "lambda",   ##supporting service id/shortname
         "arn:aws:lambda:us-east-1:444652832050:function:metricstreamprocessorinte-CloudWatchStreamFunction-bpIv5lY7e0k8" #arn

--- a/tests/unit/logs/test_transformation_full.py
+++ b/tests/unit/logs/test_transformation_full.py
@@ -110,7 +110,7 @@ CLOUDTRAIL_USER_IDENTITY = {
             "aws.service": "lambda",
             "aws.resource.id": "dynatrace-aws-logs-Lambda-1K7HG2Q2LIQKU",
             "aws.arn": "arn:aws:lambda:us-east-1:444000444:function:dynatrace-aws-logs-Lambda-1K7HG2Q2LIQKU",
-            "dt.source_entity": "AWS_LAMBDA_FUNCTION-F141CAEAE2BED565",
+            "dt.entity.aws_lambda_function": "AWS_LAMBDA_FUNCTION-F141CAEAE2BED565",
             'content': "LOG MESSAGE",
             'cloud.provider': 'aws',
             'cloud.account.id': "444000444",
@@ -145,7 +145,7 @@ CLOUDTRAIL_USER_IDENTITY = {
             "aws.service": "lambda",
             "aws.resource.id": "dynatrace-aws-logs-Lambda-1K7HG2Q2LIQKU",
             "aws.arn": "arn:aws:lambda:us-east-1:444000444:function:dynatrace-aws-logs-Lambda-1K7HG2Q2LIQKU",
-            "dt.source_entity": "AWS_LAMBDA_FUNCTION-F141CAEAE2BED565",
+            "dt.entity.aws_lambda_function": "AWS_LAMBDA_FUNCTION-F141CAEAE2BED565",
             'content': "[ERROR] UnboundLocalError: local variable 'single_log_entry' referenced before assignment\n"
                        + "Traceback (most recent call last):\n"
                        + "  File \"/var/task/lambda_function.py\", line 101, in lambda_handler\n"


### PR DESCRIPTION
PCLOUDS-3370 [Lambda integration] Add a link to generic lambda (log source) in logs provided by AWS log forwarder
PCLOUDS-3370 [Lambda integration] Allow for identical linking of Lambda logs from Log-forwarder and OA Lambda layer

when faas.id is present is logs attributes link to built-in dt.entity.aws_lambda_function (Dt cluster <263) and dt.entity.custom_device (Dt cluster 263+) is added on Dt cluster side 
dt.entity.* attributes automatically promoted to dt.source_entity on Dt cluster side if no dt.entity explicitly present (in cluster since 08.2022)

built-in lambda id still provided explicitly in log-forwarder for backward compatibility
but changed from dt.source_entity to dt.entity.aws_lambda_function to allow dt.entity.custom_device to be also promoted to dt.source_entity



Testing results in jira. I've tried some other options, but there were some issues with most of them - if you are interested, I'll put them in jira